### PR TITLE
src/start: correct cargo install cargo-generate

### DIFF
--- a/src/start/development.md
+++ b/src/start/development.md
@@ -14,7 +14,7 @@ Once you have the Rust tool-chains installed, you must also install the `bpf-lin
 
 ```console
 cargo +nightly install bpf-linker
-cargo install --git http://github.com/cargo-generate/cargo-generate
+cargo install --git http://github.com/cargo-generate/cargo-generate cargo-generate
 ```
 
 ## Starting A New Project


### PR DESCRIPTION
correct cargo install cargo-generate command

The current command produces the following error:
```
$ cargo install --git http://github.com/cargo-generate/cargo-generate
    Updating git repository `http://github.com/cargo-generate/cargo-generate`
error: multiple packages with binaries found: cargo-generate, placeholders. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify which to install.
```
`cargo install --git http://github.com/cargo-generate/cargo-generate cargo-generate` works fine.