### PR TITLE
hello-xdp: fix running command, add --path

### DIFF
--- a/src/start/hello-xdp.md
+++ b/src/start/hello-xdp.md
@@ -114,7 +114,7 @@ Let's try it out!
 
 ```console
 $ cargo build
-$ sudo ./target/debug/myapp ./target/bpfel-unknown-none/debug/myapp wlp2s0
+$ sudo ./target/debug/myapp --path ./target/bpfel-unknown-none/debug/myapp wlp2s0
 Waiting for Ctrl-C...
 Exiting...
 ```


### PR DESCRIPTION
PR fixes the command to run myapp demo application to avoid the following error:
```
$ sudo ./target/debug/myapp ./target/bpfel-unknown-none/debug/myapp
error: Found argument './target/bpfel-unknown-none/debug/myapp' which wasn't expected, or isn't valid in this context

USAGE:
    myapp [OPTIONS] --path <path>

For more information try --help
```