### PR TITLE
update the git URL for aya-gen dependency

### DIFF
--- a/src/start/logging-packets.md
+++ b/src/start/logging-packets.md
@@ -82,7 +82,7 @@ Add a new dependencies to `xtask/Cargo.toml`:
 
 ```toml
 [dependencies]
-aya-gen = { git = "http://github.com/alessandrod/aya", branch = "main" }
+aya-gen = { git = "http://github.com/aya-rs/aya", branch = "main" }
 ```
 
 Finally, we must add the command to the enum in `xtask/src/main.rs`:


### PR DESCRIPTION
http://github.com/alessandrod/aya now redirects to http://github.com/aya-rs/aya so we can use that URL directly