### PR TITLE
Update instructions for running XDP example

### DIFF
--- a/examples/myapp-00/myapp/Cargo.toml
+++ b/examples/myapp-00/myapp/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 aya = { git = "https://github.com/alessandrod/aya", branch="main" }
 myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.42"
+structopt = { version = "0.3"}
 
 [[bin]]
 name = "myapp"

--- a/examples/myapp-01/myapp-ebpf/src/main.rs
+++ b/examples/myapp-01/myapp-ebpf/src/main.rs
@@ -15,7 +15,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 }
 
 // ANCHOR: main
-#[xdp]
+#[xdp(name="myapp")]
 pub fn xdp_firewall(ctx: XdpContext) -> u32 {
     match unsafe { try_xdp_firewall(ctx) } {
         Ok(ret) => ret,

--- a/examples/myapp-01/myapp/Cargo.toml
+++ b/examples/myapp-01/myapp/Cargo.toml
@@ -9,6 +9,7 @@ aya = { git = "https://github.com/alessandrod/aya", branch="main" }
 myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.42"
 ctrlc = "3.2"
+structopt = { version = "0.3"}
 
 [[bin]]
 name = "myapp"

--- a/examples/myapp-01/myapp/src/main.rs
+++ b/examples/myapp-01/myapp/src/main.rs
@@ -25,7 +25,7 @@ fn try_main() -> Result<(), anyhow::Error> {
     };
     let iface = match env::args().nth(2) {
         Some(iface) => iface,
-        None => "eth0".to_string(),
+        None => "lo".to_string(),
     };
     let mut bpf = Bpf::load_file(&path)?;
     let probe: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;

--- a/examples/myapp-01/myapp/src/main.rs
+++ b/examples/myapp-01/myapp/src/main.rs
@@ -30,7 +30,7 @@ struct Opt {
 fn try_main() -> Result<(), anyhow::Error> {
     let opt = Opt::from_args();
     let mut bpf = Bpf::load_file(&opt.path)?;
-    let program: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
+    let program: &mut Xdp = bpf.program_mut("myapp")?.try_into()?;
     program.load()?;
     program.attach(&opt.iface, XdpFlags::default())?;
 

--- a/examples/myapp-02/myapp-ebpf/src/main.rs
+++ b/examples/myapp-02/myapp-ebpf/src/main.rs
@@ -27,7 +27,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 static mut EVENTS: PerfEventArray<PacketLog> = PerfEventArray::<PacketLog>::with_max_entries(1024, 0);
 // ANCHOR_END: map
 
-#[xdp]
+#[xdp(name="myapp")]
 pub fn xdp_firewall(ctx: XdpContext) -> u32 {
     match try_xdp_firewall(ctx) {
         Ok(ret) => ret,

--- a/examples/myapp-02/myapp-ebpf/src/main.rs
+++ b/examples/myapp-02/myapp-ebpf/src/main.rs
@@ -56,10 +56,10 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     if h_proto != ETH_P_IP {
         return Ok(xdp_action::XDP_PASS);
     }
-    let source = u32::from_be(unsafe { *ptr_at(&ctx, ETH_HDR_LEN + offset_of!(iphdr, saddr))? });
+    let dest = u32::from_be(unsafe { *ptr_at(&ctx, ETH_HDR_LEN + offset_of!(iphdr, daddr))? });
 
     let log_entry = PacketLog {
-        ipv4_address: source,
+        ipv4_address: dest,
         action: xdp_action::XDP_PASS,
     };
     unsafe {

--- a/examples/myapp-02/myapp/Cargo.toml
+++ b/examples/myapp-02/myapp/Cargo.toml
@@ -10,6 +10,8 @@ myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.42"
 bytes = "1"
 tokio = { version = "1.9.0", features = ["full"] }
+ctrlc = "3.2"
+structopt = { version = "0.3"}
 
 [[bin]]
 name = "myapp"

--- a/examples/myapp-02/myapp/src/main.rs
+++ b/examples/myapp-02/myapp/src/main.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<(), anyhow::Error> {
                     let buf = &mut buffers[i];
                     let ptr = buf.as_ptr() as *const PacketLog;
                     let data = unsafe { ptr.read_unaligned() };
-                    let src_addr = net::Ipv4Addr::from(data.ipv4_address);
-                    println!("LOG: SRC {}, ACTION {}", src_addr, data.action);
+                    let dst_addr = net::Ipv4Addr::from(data.ipv4_address);
+                    println!("LOG: DST {}, ACTION {}", dst_addr, data.action);
                 }
             }
         });

--- a/examples/myapp-02/myapp/src/main.rs
+++ b/examples/myapp-02/myapp/src/main.rs
@@ -4,6 +4,7 @@ use aya::{
     util::online_cpus,
     Bpf,
 };
+use structopt::StructOpt;
 use bytes::BytesMut;
 use std::{
     convert::{TryFrom, TryInto},
@@ -13,24 +14,22 @@ use tokio::{signal, task};
 
 use myapp_common::PacketLog;
 
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(short, long)]
+    path: String,
+    #[structopt(short, long, default_value = "eth0")]
+    iface: String,
+}
+
 // ANCHOR: main
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let path = match env::args().nth(1) {
-        Some(iface) => iface,
-        None => panic!("not path provided"),
-    };
-    let iface = match env::args().nth(2) {
-        Some(iface) => iface,
-        None => "lo".to_string(),
-    };
-
-    let data = fs::read(path)?;
-    let mut bpf = Bpf::load(&data)?;
-
-    let probe: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
-    probe.load()?;
-    probe.attach(&iface, XdpFlags::default())?;
+    let opt = Opt::from_args();
+    let mut bpf = Bpf::load_file(&opt.path)?;
+    let program: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
+    program.load()?;
+    program.attach(&opt.iface, XdpFlags::default())?;
 
     // ANCHOR: map
     let mut perf_array = AsyncPerfEventArray::try_from(bpf.map_mut("EVENTS")?)?;

--- a/examples/myapp-02/myapp/src/main.rs
+++ b/examples/myapp-02/myapp/src/main.rs
@@ -27,7 +27,7 @@ struct Opt {
 async fn main() -> Result<(), anyhow::Error> {
     let opt = Opt::from_args();
     let mut bpf = Bpf::load_file(&opt.path)?;
-    let program: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
+    let program: &mut Xdp = bpf.program_mut("myapp")?.try_into()?;
     program.load()?;
     program.attach(&opt.iface, XdpFlags::default())?;
 

--- a/examples/myapp-02/myapp/src/main.rs
+++ b/examples/myapp-02/myapp/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let iface = match env::args().nth(2) {
         Some(iface) => iface,
-        None => "eth0".to_string(),
+        None => "lo".to_string(),
     };
 
     let data = fs::read(path)?;

--- a/examples/myapp-03/myapp-ebpf/src/main.rs
+++ b/examples/myapp-03/myapp-ebpf/src/main.rs
@@ -33,7 +33,7 @@ static mut EVENTS: PerfEventArray<PacketLog> =
 static mut BLOCKLIST: HashMap<u32, u32> = HashMap::<u32, u32>::with_max_entries(1024, 0);
 // ANCHOR_END: blocklist
 
-#[xdp]
+#[xdp(name="myapp")]
 pub fn xdp_firewall(ctx: XdpContext) -> u32 {
     match try_xdp_firewall(ctx) {
         Ok(ret) => ret,

--- a/examples/myapp-03/myapp-ebpf/src/main.rs
+++ b/examples/myapp-03/myapp-ebpf/src/main.rs
@@ -68,10 +68,10 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     if h_proto != ETH_P_IP {
         return Ok(xdp_action::XDP_PASS);
     }
-    let source = u32::from_be(unsafe { *ptr_at(&ctx, ETH_HDR_LEN + offset_of!(iphdr, saddr))? });
+    let daddr = u32::from_be(unsafe { *ptr_at(&ctx, ETH_HDR_LEN + offset_of!(iphdr, daddr))? });
 
     // ANCHOR: action
-    let action = if block_ip(source) {
+    let action = if block_ip(daddr) {
         xdp_action::XDP_DROP
     } else {
         xdp_action::XDP_PASS
@@ -79,7 +79,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     // ANCHOR_END: action
 
     let log_entry = PacketLog {
-        ipv4_address: source,
+        ipv4_address: daddr,
         action: action,
     };
 

--- a/examples/myapp-03/myapp/Cargo.toml
+++ b/examples/myapp-03/myapp/Cargo.toml
@@ -10,6 +10,7 @@ myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.42"
 bytes = "1"
 tokio = { version = "1.9.0", features = ["full"] }
+structopt = { version = "0.3"}
 
 [[bin]]
 name = "myapp"

--- a/examples/myapp-03/myapp/src/main.rs
+++ b/examples/myapp-03/myapp/src/main.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // ANCHOR: block_address
     let mut blocklist: HashMap<_, u32, u32> = HashMap::try_from(bpf.map_mut("BLOCKLIST")?)?;
     // Let's block localhost IP addresses
-    let block_addr : u32 = Ipv4Addr::new(127, 0, 0, 1).try_into()?;
+    let block_addr : u32 = Ipv4Addr::new(192, 168, 0, 10).try_into()?;
     blocklist.insert(block_addr, 0, 0)?;
     // ANCHOR_END: block_address
 

--- a/examples/myapp-03/myapp/src/main.rs
+++ b/examples/myapp-03/myapp/src/main.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let iface = match env::args().nth(2) {
         Some(iface) => iface,
-        None => "eth0".to_string(),
+        None => "lo".to_string(),
     };
 
     let data = fs::read(path)?;

--- a/examples/myapp-03/myapp/src/main.rs
+++ b/examples/myapp-03/myapp/src/main.rs
@@ -1,38 +1,41 @@
 use aya::{
     maps::HashMap,
-    maps::perf::{AsyncPerfEventArray},
+    maps::perf::AsyncPerfEventArray,
     programs::{Xdp, XdpFlags},
     util::online_cpus,
     Bpf,
 };
+use structopt::StructOpt;
 use bytes::BytesMut;
-use std::{convert::{TryFrom, TryInto}, env, fs, net::{self, Ipv4Addr}};
+use std::{
+    convert::{TryFrom, TryInto}, 
+    env, fs, net::{self, Ipv4Addr},
+};
 use tokio::{signal, task};
 
 use myapp_common::PacketLog;
 
+#[derive(Debug, StructOpt)]
+struct Opt {
+    #[structopt(short, long)]
+    path: String,
+    #[structopt(short, long, default_value = "eth0")]
+    iface: String,
+}
+
 // ANCHOR: main
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let path = match env::args().nth(1) {
-        Some(iface) => iface,
-        None => panic!("not path provided"),
-    };
-    let iface = match env::args().nth(2) {
-        Some(iface) => iface,
-        None => "lo".to_string(),
-    };
-
-    let data = fs::read(path)?;
-    let mut bpf = Bpf::load(&data)?;
-
-    let probe: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
-    probe.load()?;
-    probe.attach(&iface, XdpFlags::default())?;
+    let opt = Opt::from_args();
+    let mut bpf = Bpf::load_file(&opt.path)?;
+    let program: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
+    program.load()?;
+    program.attach(&opt.iface, XdpFlags::default())?;
 
     // ANCHOR: block_address
     let mut blocklist: HashMap<_, u32, u32> = HashMap::try_from(bpf.map_mut("BLOCKLIST")?)?;
-    let block_addr : u32 = Ipv4Addr::new(1, 1, 1, 1).try_into()?;
+    // Let's block localhost IP addresses
+    let block_addr : u32 = Ipv4Addr::new(127, 0, 0, 1).try_into()?;
     blocklist.insert(block_addr, 0, 0)?;
     // ANCHOR_END: block_address
 

--- a/examples/myapp-03/myapp/src/main.rs
+++ b/examples/myapp-03/myapp/src/main.rs
@@ -34,7 +34,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // ANCHOR: block_address
     let mut blocklist: HashMap<_, u32, u32> = HashMap::try_from(bpf.map_mut("BLOCKLIST")?)?;
-    // Let's block localhost IP addresses
     let block_addr : u32 = Ipv4Addr::new(192, 168, 0, 10).try_into()?;
     blocklist.insert(block_addr, 0, 0)?;
     // ANCHOR_END: block_address
@@ -57,8 +56,8 @@ async fn main() -> Result<(), anyhow::Error> {
                     let buf = &mut buffers[i];
                     let ptr = buf.as_ptr() as *const PacketLog;
                     let data = unsafe { ptr.read_unaligned() };
-                    let src_addr = net::Ipv4Addr::from(data.ipv4_address);
-                    println!("LOG: SRC {}, ACTION {}", src_addr, data.action);
+                    let dst_addr = net::Ipv4Addr::from(data.ipv4_address);
+                    println!("LOG: DST {}, ACTION {}", dst_addr, data.action);
                 }
             }
         });

--- a/examples/myapp-03/myapp/src/main.rs
+++ b/examples/myapp-03/myapp/src/main.rs
@@ -28,7 +28,7 @@ struct Opt {
 async fn main() -> Result<(), anyhow::Error> {
     let opt = Opt::from_args();
     let mut bpf = Bpf::load_file(&opt.path)?;
-    let program: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;
+    let program: &mut Xdp = bpf.program_mut("myapp")?.try_into()?;
     program.load()?;
     program.attach(&opt.iface, XdpFlags::default())?;
 

--- a/src/start/dropping-packets.md
+++ b/src/start/dropping-packets.md
@@ -14,6 +14,8 @@ Therefore:
 - Check the destination IP Address from the packet against the HashMap to make a forwarding decision
 - Add entries to the blocklist from userspace
 
+The source for this chapter can be found [here](https://github.com/aya-rs/book/tree/main/examples/myapp-03).
+
 ### eBPF: Map Creation
 
 Let's create a new map called `BLOCKLIST` in `myapp-ebpf/src/main.rs`
@@ -44,7 +46,7 @@ Once we have it, it's simply a case of calling `blocklist.insert()`.
 We'll use the `IPv4Addr` type to represent our IP address as it's human-readable and can be easily converted to a `u32`. We'll block all traffic **to** `192.168.0.10` sent over the `eth0` interface, for this example.
 
 ```rust,ignore
-{{#rustdoc_include ../../examples/myapp-02/myapp/src/main.rs:block_address}}
+{{#rustdoc_include ../../examples/myapp-03/myapp/src/main.rs:block_address}}
 ```
 
 > 💡 **HINT: A quick note on Endianness**

--- a/src/start/dropping-packets.md
+++ b/src/start/dropping-packets.md
@@ -69,7 +69,7 @@ sudo ./target/debug/myapp --path ./target/bpfel-unknown-none/debug/myapp --iface
 ### Testing the Allowed IP addresses
 
 ```console
-curl --interface eth0 192.168.0.22
+curl 192.168.0.22
 ```
 
 ```console
@@ -79,7 +79,7 @@ LOG: DST 192.168.0.22, ACTION 2
 
 ### Testing the Blocked IP address
 ```console
-curl --interface eth0 192.168.0.10
+curl 192.168.0.10
 ```
 
 ```console

--- a/src/start/dropping-packets.md
+++ b/src/start/dropping-packets.md
@@ -41,7 +41,7 @@ We'll then call `block_ip` to determine the fate of the packet:
 
 In order to add addresses to block, we first need to get a reference to the `BLOCKLIST` map.
 Once we have it, it's simply a case of calling `blocklist.insert()`.
-We'll use the `IPv4Addr` type to represent our IP address as it's human-readable and can be easily converted to a `u32`. We'll block all traffic **to** `192.168.0.10` sent over the `lo` interface, for this example.
+We'll use the `IPv4Addr` type to represent our IP address as it's human-readable and can be easily converted to a `u32`. We'll block all traffic **to** `192.168.0.10` sent over the `eth0` interface, for this example.
 
 ```rust,ignore
 {{#rustdoc_include ../../examples/myapp-02/myapp/src/main.rs:block_address}}
@@ -61,26 +61,26 @@ We'll use the `IPv4Addr` type to represent our IP address as it's human-readable
 ```console
 cargo build
 cargo xtask build-ebpf
-sudo ./target/debug/myapp --path ./target/bpfel-unknown-none/debug/myapp --intf lo
+sudo ./target/debug/myapp --path ./target/bpfel-unknown-none/debug/myapp --iface eth0
 ```
 
 ### Testing the Allowed IP addresses
 
 ```console
-curl --interface lo 192.168.0.22
+curl --interface eth0 192.168.0.22
 ```
 
 ```console
-LOG: SRC 192.168.0.22, ACTION 2
-LOG: SRC 192.168.0.22, ACTION 2
+LOG: DST 192.168.0.22, ACTION 2
+LOG: DST 192.168.0.22, ACTION 2
 ```
 
 ### Testing the Blocked IP address
 ```console
-curl --interface lo 192.168.0.10
+curl --interface eth0 192.168.0.10
 ```
 
 ```console
-LOG: SRC 192.168.0.10, ACTION 1
-LOG: SRC 192.168.0.10, ACTION 1
+LOG: DST 192.168.0.10, ACTION 1
+LOG: DST 192.168.0.10, ACTION 1
 ```

--- a/src/start/hello-xdp.md
+++ b/src/start/hello-xdp.md
@@ -8,6 +8,8 @@ XDP (eXpress Data Path) programs permit our eBPF program to make decisions about
 
 > In this example you will be attaching XDP programs to a network interface. The guide assumes you have an interface called `eth0`, but you may select any NIC on your machine.
 
+The source for this chapter can be found [here](https://github.com/aya-rs/book/tree/main/examples/myapp-01).
+
 ## eBPF Component
 
 ### Permit All

--- a/src/start/hello-xdp.md
+++ b/src/start/hello-xdp.md
@@ -4,7 +4,9 @@
 
 While there are myriad trace points to attach to and program types to write we should start somewhere simple.
 
-XDP (eXpress Data Path) programs permit our eBPF program to make decisions about packets that have been received on the interface to which our program is attached. To keep things simple, we'll build a very simplistic firewall to permit or deny traffic.
+XDP (eXpress Data Path) programs permit our eBPF program to make decisions about packets that have been sent out on the interface to which our program is attached. To keep things simple, we'll build a very simplistic firewall to permit or deny traffic.
+
+> In this example you will be attaching XDP programs to a network interface. The guide assumes you have an interface called `eth0`, but you may select any NIC on your machine.
 
 ## eBPF Component
 

--- a/src/start/hello-xdp.md
+++ b/src/start/hello-xdp.md
@@ -35,7 +35,7 @@ Then our application logic:
 {{#rustdoc_include ../../examples/myapp-01/myapp-ebpf/src/main.rs:main }}
 ```
 
-- `#[xdp]` indicates that this function is an XDP program
+- `#[xdp(name="myapp")]` indicates that this function is an XDP program
 - The `try_xdp_firewall` function returns a Result that permits all traffic
 - The `xdp_firewall` program calls `try_xdp_firewall` and handles any errors by returning `XDP_ABORTED`, which will drop the packet and raise a tracepoint exception.
 
@@ -106,7 +106,7 @@ The line `let mut bpf = Bpf::load_file(&path)?;`:
 - Creates any maps
 - If your system supports BPF Type Format (BTF), it will read the current BTF description and performs any necessary relocations
 
-Once our file is loaded, we can extract the XDP probe with `let probe: &mut Xdp = bpf.program_mut("xdp")?.try_into()?;` and then load it in to the kernel with `probe.load()`.
+Once our file is loaded, we can extract the XDP probe with `let probe: &mut Xdp = bpf.program_mut("myapp")?.try_into()?;` and then load it in to the kernel with `probe.load()`.
 
 Finally, we can attach it to an interface with `probe.attach(&iface, XdpFlags::default())?;`
 

--- a/src/start/hello-xdp.md
+++ b/src/start/hello-xdp.md
@@ -4,9 +4,29 @@
 
 While there are myriad trace points to attach to and program types to write we should start somewhere simple.
 
-XDP (eXpress Data Path) programs permit our eBPF program to make decisions about packets that have been sent out on the interface to which our program is attached. To keep things simple, we'll build a very simplistic firewall to permit or deny traffic.
+XDP (eXpress Data Path) programs permit our eBPF program to make decisions about packets that have been received on the interface to which our program is attached. To keep things simple, we'll build a very simplistic firewall to permit or deny traffic.
 
 > In this example you will be attaching XDP programs to a network interface. The guide assumes you have an interface called `eth0`, but you may select any NIC on your machine.
+> 
+> For a list of interfaces you can use `ip addr list`,
+> ```console
+> 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+>     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+>     inet 127.0.0.1/8 scope host lo
+>        valid_lft forever preferred_lft forever
+>     inet6 ::1/128 scope host 
+>        valid_lft forever preferred_lft forever
+> 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
+>     link/ether 00:1c:42:79:b1:a2 brd ff:ff:ff:ff:ff:ff
+>     inet 10.211.55.6/24 brd 10.211.55.255 scope global dynamic noprefixroute eth0
+>        valid_lft 1348sec preferred_lft 1348sec
+>     inet6 fdb2:2c26:f4e4:0:ea92:21e7:8874:c835/64 scope global temporary dynamic 
+>        valid_lft 604351sec preferred_lft 85629sec
+>     inet6 fdb2:2c26:f4e4:0:9f8d:b814:392f:aa04/64 scope global dynamic mngtmpaddr noprefixroute 
+>        valid_lft 2591645sec preferred_lft 604445sec
+>     inet6 fe80::f1e5:4c79:35e6:78e/64 scope link noprefixroute 
+>        valid_lft forever preferred_lft forever
+> ```
 
 The source for this chapter can be found [here](https://github.com/aya-rs/book/tree/main/examples/myapp-01).
 

--- a/src/start/logging-packets.md
+++ b/src/start/logging-packets.md
@@ -3,6 +3,7 @@
 In the previous chapter, our XDP application ran for 10 seconds and permitted some traffic.
 There was however no output on the console, so you just have to trust that it was working correctly. Let's expand this program to log the traffic that is being permitted
 
+The source for this chapter can be found [here](https://github.com/aya-rs/book/tree/main/examples/myapp-02).
 
 ## Getting Data to User-Space
 

--- a/src/start/logging-packets.md
+++ b/src/start/logging-packets.md
@@ -124,7 +124,7 @@ With our helper function in place, we can:
 1. Read the Ethertype field to check if we have an IPv4 packet.
 1. Read the IPv4 Source Address from the IP header
 
-First let's add another dependency on `memoffset = "0.6"` to `myapp-ebpf/Cargo.toml`, and then we'll change our `try_xdp_firewall` function to look like this:
+First let's add another dependency on `memoffset = "0.6.4"` to `myapp-ebpf/Cargo.toml`, and then we'll change our `try_xdp_firewall` function to look like this:
 
 ```rust,ignore
 {{#rustdoc_include ../../examples/myapp-02/myapp-ebpf/src/main.rs:try}}
@@ -167,15 +167,15 @@ We no longer need to sleep, as we run until we receive the `CTRL+C` signal.
 ```console
 cargo build
 cargo xtask build-ebpf
-sudo ./target/debug/myapp ./target/bpfel-unknown-none/debug/myapp wlp2s0
+sudo ./target/debug/myapp ./target/bpfel-unknown-none/debug/myapp lo
 ```
 
 ```console
-LOG: SRC 192.168.1.205, ACTION 2
-LOG: SRC 192.168.1.21, ACTION 2
-LOG: SRC 192.168.1.21, ACTION 2
-LOG: SRC 18.168.253.132, ACTION 2
-LOG: SRC 18.168.253.132, ACTION 2
-LOG: SRC 18.168.253.132, ACTION 2
-LOG: SRC 140.82.121.6, ACTION 2
+LOG: SRC 127.0.0.1, ACTION 2
+LOG: SRC 127.0.0.53, ACTION 2
+LOG: SRC 127.0.0.1, ACTION 2
+LOG: SRC 127.0.0.53, ACTION 2
+LOG: SRC 127.0.0.1, ACTION 2
+LOG: SRC 127.0.0.1, ACTION 2
+LOG: SRC 127.0.0.1, ACTION 2
 ```

--- a/src/start/logging-packets.md
+++ b/src/start/logging-packets.md
@@ -57,10 +57,10 @@ Now we've got our maps set up, let's add some data!
 ### Generating Bindings To vmlinux.h
 
 To get useful data to add to our maps, we first need some useful data structures to populate with data from the `XdpContext`.
-We want to log the Source IP Address of incoming traffic, so we'll need to:
+We want to log the Destination IP Address of incoming traffic, so we'll need to:
 
 1. Read the Ethernet Header to determine if this is an IPv4 Packet
-1. Read the Source IP Address from the IPv4 Header
+1. Read the Destination IP Address from the IPv4 Header
 
 The two structs in the kernel for this are `ethhdr` from `uapi/linux/if_ether.h` and `iphdr` from `uapi/linux/ip.h`.
 If I were to use bindgen to generate Rust bindings for those headers, I'd be tied to the kernel version of the system that I'm developing on.
@@ -135,7 +135,7 @@ First let's add another dependency on `memoffset = "0.6.4"` to `myapp-ebpf/Cargo
 > As there is limited stack space, it's more memory efficient to use the `offset_of!` macro to read
 > a single field from a struct, rather than reading the whole struct and accessing the field by name.
 
-Once we have our IPv4 source address, we can create a `PacketLog` struct and output this to our PerfEventArray
+Once we have our IPv4 destination address, we can create a `PacketLog` struct and output this to our PerfEventArray
 
 ## Reading Data
 
@@ -171,11 +171,7 @@ sudo ./target/debug/myapp ./target/bpfel-unknown-none/debug/myapp lo
 ```
 
 ```console
-LOG: SRC 127.0.0.1, ACTION 2
-LOG: SRC 127.0.0.53, ACTION 2
-LOG: SRC 127.0.0.1, ACTION 2
-LOG: SRC 127.0.0.53, ACTION 2
-LOG: SRC 127.0.0.1, ACTION 2
-LOG: SRC 127.0.0.1, ACTION 2
-LOG: SRC 127.0.0.1, ACTION 2
+LOG: DST 192.168.0.10, ACTION 2
+LOG: DST 192.168.0.10, ACTION 2
+LOG: DST 192.168.0.10, ACTION 2
 ```


### PR DESCRIPTION
Closes #14 

- Logging Packet document instructions updated with `lo` (localhost)
interface as the example since eth0 may not be available on all machines
- Update template files for the example application with missing
dependencies and import statement. Switch from eth0 interface to lo
interface

Signed-off-by: Nitish Malhotra <nitish.malhotra@gmail.com>