### PR TITLE
development: Use the latest release of cargo-generate instead of git

### DIFF
--- a/src/start/development.md
+++ b/src/start/development.md
@@ -14,12 +14,12 @@ Once you have the Rust toolchains installed, you must also install the `bpf-link
 
 ```console
 cargo install bpf-linker
-cargo install --git https://github.com/cargo-generate/cargo-generate cargo-generate
+cargo install cargo-generate
 ```
 
 If you have LLVM installed and want to use it instead of rust-llvm, you can use the system-llvm feature:
 ```console
-cargo install --git https://github.com/aya-rs/bpf-linker  --tag v0.9.3 --no-default-features --features system-llvm -- bpf-linker
+cargo install --git https://github.com/aya-rs/bpf-linker --tag v0.9.3 --no-default-features --features system-llvm -- bpf-linker
 ```
 
 ## Starting A New Project
@@ -40,4 +40,5 @@ or
 cargo generate --name tcfw -d program_type=classifier -d direction=Ingress https://github.com/aya-rs/aya-template
 ```
 
-See https://github.com/aya-rs/aya-template/blob/main/cargo-generate.toml for the full list of available options.
+See [the cargo-generate.toml file (in the aya-template repository)](https://github.com/aya-rs/aya-template/blob/main/cargo-generate.toml)
+for the full list of available options.


### PR DESCRIPTION
Dave's changes were already released in 0.9.0[0][1], now there is 0.13.0
released, we are more than fine to just use the latest release.

[0] https://github.com/cargo-generate/cargo-generate/commit/cf12f1d6ba1721a1007999dee90348f6eaa1dca0
[1] https://github.com/cargo-generate/cargo-generate/commit/ef81aefab51f92e695225db65b2248f8b6ace46f

Co-authored-by: Dmitry Savintsev <dsavints@gmail.com>
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>
Signed-off-by: Dmitry Savintsev <dsavints@gmail.com>