### PR TITLE
fix for btf_types::generate API change

### DIFF
--- a/examples/myapp-02/xtask/src/codegen.rs
+++ b/examples/myapp-02/xtask/src/codegen.rs
@@ -8,7 +8,7 @@ use std::{
 pub fn generate() -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("myapp-ebpf/src");
     let names: Vec<&str> = vec!["ethhdr", "iphdr"];
-    let bindings = btf_types::generate(Path::new("/sys/kernel/btf/vmlinux"), &names, true)?;
+    let bindings = btf_types::generate(Path::new("/sys/kernel/btf/vmlinux"), &names)?;
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let mut out = File::create(dir.join("bindings.rs"))?;
     write!(out, "{}", bindings)?;

--- a/examples/myapp-03/xtask/src/codegen.rs
+++ b/examples/myapp-03/xtask/src/codegen.rs
@@ -8,7 +8,7 @@ use std::{
 pub fn generate() -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("myapp-ebpf/src");
     let names: Vec<&str> = vec!["ethhdr", "iphdr"];
-    let bindings = btf_types::generate(Path::new("/sys/kernel/btf/vmlinux"), &names, true)?;
+    let bindings = btf_types::generate(Path::new("/sys/kernel/btf/vmlinux"), &names)?;
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let mut out = File::create(dir.join("bindings.rs"))?;
     write!(out, "{}", bindings)?;


### PR DESCRIPTION
PR modifies the number of arguments in `btf_types::generate` to avoid build error.

Related to https://github.com/aya-rs/aya/commit/9a33b6b654e3e2c03774e12e1c10cc728483fd1a?diff=unified#diff-c6cee644cf972b498b301db1a8309d9c6c00d9c563242fda141dd911b286a6b6