### PR TITLE
move Development Environment out of XDP example

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,9 +60,9 @@ nav:
     - index.md
   - Getting Started:
     - book/index.md
+    - Development Environment: book/start/development.md
     - A Simple XDP Program:
       - book/start/index.md
-      - Development Environment: book/start/development.md
       - Hello XDP!: book/start/hello-xdp.md
       - Logging Packets: book/start/logging-packets.md
       - Dropping Packets: book/start/dropping-packets.md


### PR DESCRIPTION
PR moves the "Development Environment" section of the book (currently https://aya-rs.dev/book/start/development/) one level up, to be on the same level and before "A Simple XDP Program".  The Development Environment instructions are relevant not only to the XDP but to any type of Aya program. It would be good to make it "top-level visible" in case someone doesn't think of expanding "A Simple XDP Program".

Signed-off-by: Dmitry Savintsev <dsavints@gmail.com>