### PR TITLE
development: Always install bpf-linker from crates, not from git

### DIFF
--- a/docs/book/start/development.md
+++ b/docs/book/start/development.md
@@ -23,7 +23,7 @@ If you are running **macos, or linux on any other architecture**, you need to
 install LLVM 14 first, then install the linker with:
 
 ```console
-cargo install --git https://github.com/aya-rs/bpf-linker --tag v0.9.4 --no-default-features --features system-llvm -- bpf-linker
+cargo install --no-default-features --features system-llvm bpf-linker
 ```
 
 To generate the scaffolding for your project, you're going to need


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>