### PR TITLE
cgroup-skb: Ensure that we dereference __sk_buff, not SkBuffContext

### DIFF
--- a/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
@@ -38,7 +38,7 @@ fn block_ip(address: u32) -> bool {
 }
 
 fn try_cgroup_skb_egress(ctx: SkBuffContext) -> Result<i32, i64> {
-    let protocol = unsafe { (*ctx.skb).protocol };
+    let protocol = unsafe { (*(ctx.skb)).protocol };
     if protocol != ETH_P_IP {
         return Ok(1);
     }


### PR DESCRIPTION
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>