### PR TITLE
Updating aya-rs/aya-log references to aya-rs/aya

### DIFF
--- a/examples/aya-tool/myapp-ebpf/Cargo.toml
+++ b/examples/aya-tool/myapp-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 myapp-common = { path = "../myapp-common" }
 
 [[bin]]

--- a/examples/myapp-01/myapp-ebpf/Cargo.toml
+++ b/examples/myapp-01/myapp-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 myapp-common = { path = "../myapp-common" }
 
 [[bin]]

--- a/examples/myapp-02/myapp-ebpf/Cargo.toml
+++ b/examples/myapp-02/myapp-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 myapp-common = { path = "../myapp-common" }
 memoffset = "0.6"
 

--- a/examples/myapp-03/myapp-ebpf/Cargo.toml
+++ b/examples/myapp-03/myapp-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 myapp-common = { path = "../myapp-common" }
 memoffset = "0.6"
 

--- a/examples/tc-egress/tc-egress-ebpf/Cargo.toml
+++ b/examples/tc-egress/tc-egress-ebpf/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aya-bpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya-log", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 tc-egress-common = { path = "../tc-egress-common" }
 memoffset = "0.6"
 


### PR DESCRIPTION
This crate has been moved from aya-rs/aya-log into the aya repository as of July-ish this year according to the aya-log git history.  Several of the examples in the book were not working as expected (myapp-01 for example was not emitting the format string for ebpf logging macro invocations) so by updating these Cargo.toml deps to point at the new crate version we can get the examples back to working out-of-the-box.

This will also help avoid having potential future users depending on the old/deprecated version of this crate.  I would suggest also adding additional instructions to the old crate's README.