### PR TITLE
Fix bindgen installation command

### DIFF
--- a/docs/book/programs/cgroup-skb.md
+++ b/docs/book/programs/cgroup-skb.md
@@ -40,7 +40,7 @@ represents the IP protocol header. We need to generate Rust bindings to it.
 
 First, we must make sure that `bindgen` is installed.
 ```sh
-cargo install bindgen
+cargo install bindgen-cli
 ```
 
 Let's use `xtask` to automate the process of generating bindings so we can

--- a/docs/book/start/logging-packets.md
+++ b/docs/book/start/logging-packets.md
@@ -101,7 +101,7 @@ This is where `aya-tool` comes in to play. It can easily generate bindings for u
 
 First, we must make sure that `bindgen` is installed.
 ```sh
-cargo install bindgen
+cargo install bindgen-cli
 ```
 
 Once the bindings are generated and checked in to our repository they shouldn't need to be regenerated again unless we need to add a new struct.


### PR DESCRIPTION
The `bindgen` has changed to a workspace member:

https://github.com/rust-lang/rust-bindgen/commits/master/bindgen-cli

Signed-off-by: Eval EXEC <execvy@gmail.com>
