### PR TITLE
examples: Pin Rust nightly to 2023-01-10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2023-01-10
           components: rust-src
 
       - name: Install bpf-linker
-        run: cargo +nightly install bpf-linker
+        run: cargo install bpf-linker
 
       - uses: Swatinem/rust-cache@v1
 

--- a/examples/aya-tool/myapp-ebpf/rust-toolchain.toml
+++ b/examples/aya-tool/myapp-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/aya-tool/xtask/src/build_ebpf.rs
+++ b/examples/aya-tool/xtask/src/build_ebpf.rs
@@ -43,7 +43,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("myapp-ebpf");
     let target = format!("--target={}", opts.target);
     let args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -52,8 +51,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
         "--profile",
         opts.profile.as_str(),
     ];
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/rust-toolchain.toml
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/cgroup-skb-egress/xtask/src/build_ebpf.rs
+++ b/examples/cgroup-skb-egress/xtask/src/build_ebpf.rs
@@ -44,7 +44,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("cgroup-skb-egress-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -54,8 +53,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/kprobetcp/kprobetcp-ebpf/rust-toolchain.toml
+++ b/examples/kprobetcp/kprobetcp-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/kprobetcp/xtask/src/build_ebpf.rs
+++ b/examples/kprobetcp/xtask/src/build_ebpf.rs
@@ -43,7 +43,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("kprobetcp-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -53,8 +52,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/lsm-nice/lsm-nice-ebpf/rust-toolchain.toml
+++ b/examples/lsm-nice/lsm-nice-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/lsm-nice/xtask/src/build_ebpf.rs
+++ b/examples/lsm-nice/xtask/src/build_ebpf.rs
@@ -43,7 +43,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("lsm-nice-ebpf");
     let target = format!("--target={}", opts.target);
     let args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -52,8 +51,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
         "--profile",
         opts.profile.as_str(),
     ];
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/tc-egress/tc-egress-ebpf/rust-toolchain.toml
+++ b/examples/tc-egress/tc-egress-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/tc-egress/xtask/src/build_ebpf.rs
+++ b/examples/tc-egress/xtask/src/build_ebpf.rs
@@ -44,7 +44,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("tc-egress-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -54,8 +53,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/xdp-drop/xdp-drop-ebpf/rust-toolchain.toml
+++ b/examples/xdp-drop/xdp-drop-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/xdp-drop/xtask/src/build_ebpf.rs
+++ b/examples/xdp-drop/xtask/src/build_ebpf.rs
@@ -44,7 +44,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("xdp-drop-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -54,8 +53,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/xdp-hello/xdp-hello-ebpf/rust-toolchain.toml
+++ b/examples/xdp-hello/xdp-hello-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/xdp-hello/xtask/src/build_ebpf.rs
+++ b/examples/xdp-hello/xtask/src/build_ebpf.rs
@@ -44,7 +44,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("xdp-hello-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -54,8 +53,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");

--- a/examples/xdp-log/xdp-log-ebpf/rust-toolchain.toml
+++ b/examples/xdp-log/xdp-log-ebpf/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel="nightly"
+channel="nightly-2023-01-10"

--- a/examples/xdp-log/xtask/src/build_ebpf.rs
+++ b/examples/xdp-log/xtask/src/build_ebpf.rs
@@ -44,7 +44,6 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("xdp-log-ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
         "build",
         "--verbose",
         target.as_str(),
@@ -54,8 +53,14 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     if opts.release {
         args.push("--release")
     }
+
+    // Command::new creates a child process which inherits all env variables. This means env
+    // vars set by the cargo xtask command are also inherited. RUSTUP_TOOLCHAIN is removed
+    // so the rust-toolchain.toml file in the -ebpf folder is honored.
+
     let status = Command::new("cargo")
         .current_dir(&dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .args(&args)
         .status()
         .expect("failed to build bpf program");


### PR DESCRIPTION
We need to wait for the following fixes in Rust nightly to be able to use the newest one:

* https://github.com/rust-lang/rust/pull/106796
* https://github.com/rust-lang/rust/pull/106856

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>