### PR TITLE
fix network to host endiannes for ipv4

### DIFF
--- a/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
+++ b/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
@@ -60,7 +60,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     }
 
     let ipv4hdr: *const Ipv4Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-    let source = unsafe { (*ipv4hdr).src_addr };
+    let source =  u32::from_be(unsafe { (*ipv4hdr).src_addr });
 
     // (3)
     let action = if block_ip(source) {

--- a/examples/xdp-log/xdp-log-ebpf/src/main.rs
+++ b/examples/xdp-log/xdp-log-ebpf/src/main.rs
@@ -47,7 +47,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     }
 
     let ipv4hdr: *const Ipv4Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-    let source_addr = unsafe { (*ipv4hdr).src_addr };
+    let source_addr = u32::from_be(unsafe { (*ipv4hdr).src_addr });
 
     let source_port = match unsafe { (*ipv4hdr).proto } {
         IpProto::Tcp => {


### PR DESCRIPTION
The book perfectly [describes](https://github.com/aya-rs/book/blob/main/docs/book/start/dropping-packets.md#populating-our-map-from-userspace) the issue that `u32::from_be()` solves, however the code for it was missing in both `xdp-log` and `xdp-drop` examples.