### PR TITLE
examples: upgrade tokio dep to 1.24

### DIFF
--- a/examples/aya-tool/myapp/Cargo.toml
+++ b/examples/aya-tool/myapp/Cargo.toml
@@ -11,7 +11,7 @@ myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.68"
 ctrlc = "3.2"
 structopt = { version = "0.3"}
-tokio = { version = "1.14", features = ["full"] }
+tokio = { version = "1.24", features = ["full"] }
 env_logger = "0.10"
 log = "0.4"
 

--- a/examples/cgroup-skb-egress/cgroup-skb-egress/Cargo.toml
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.68"
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"
-tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 bytes = "1"
 
 [[bin]]

--- a/examples/kprobetcp/kprobetcp/Cargo.toml
+++ b/examples/kprobetcp/kprobetcp/Cargo.toml
@@ -15,13 +15,7 @@ anyhow = "1.0.68"
 clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"
-tokio = { version = "1.23", features = [
-    "macros",
-    "rt",
-    "rt-multi-thread",
-    "net",
-    "signal",
-] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 
 [[bin]]
 name = "kprobetcp"

--- a/examples/lsm-nice/lsm-nice/Cargo.toml
+++ b/examples/lsm-nice/lsm-nice/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.68"
 
 log = "0.4"
 structopt = { version = "0.3" }
-tokio = { version = "1.5.0", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 env_logger = "0.10"
 
 [[bin]]

--- a/examples/tc-egress/tc-egress/Cargo.toml
+++ b/examples/tc-egress/tc-egress/Cargo.toml
@@ -11,7 +11,7 @@ tc-egress-common = { path = "../tc-egress-common", features=["user"] }
 anyhow = "1.0.68"
 clap = { version = "3.2", features = ["derive"] }
 log = "0.4"
-tokio = { version = "1.23", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 bytes = "1"
 env_logger = "0.10"
 

--- a/examples/xdp-drop/xdp-drop/Cargo.toml
+++ b/examples/xdp-drop/xdp-drop/Cargo.toml
@@ -11,7 +11,7 @@ xdp-drop-common = { path = "../xdp-drop-common", features = ["user"] }
 anyhow = "1.0.68"
 clap = { version = "3.1", features = ["derive"] }
 log = "0.4"
-tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 bytes = "1"
 env_logger = "0.10"
 

--- a/examples/xdp-hello/xdp-hello/Cargo.toml
+++ b/examples/xdp-hello/xdp-hello/Cargo.toml
@@ -11,7 +11,7 @@ xdp-hello-common = { path = "../xdp-hello-common", features = ["user"] }
 anyhow = "1.0.68"
 clap = { version = "3.1", features = ["derive"] }
 log = "0.4"
-tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 env_logger = "0.10"
 
 [[bin]]

--- a/examples/xdp-log/xdp-log/Cargo.toml
+++ b/examples/xdp-log/xdp-log/Cargo.toml
@@ -11,7 +11,7 @@ xdp-log-common = { path = "../xdp-log-common", features = ["user"] }
 anyhow = "1.0.68"
 clap = { version = "3.1", features = ["derive"] }
 log = "0.4"
-tokio = { version = "1.18", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
 bytes = "1"
 env_logger = "0.10"
 


### PR DESCRIPTION
PR updates the tokio dependency to 1.24 in the examples.