### PR TITLE
remove unused structopt dependency in aya-tool example

### DIFF
--- a/examples/aya-tool/myapp/Cargo.toml
+++ b/examples/aya-tool/myapp/Cargo.toml
@@ -10,7 +10,6 @@ aya-log = "0.1"
 myapp-common = { path = "../myapp-common", features=["userspace"] }
 anyhow = "1.0.68"
 ctrlc = "3.2"
-structopt = { version = "0.3"}
 tokio = { version = "1.24", features = ["full"] }
 env_logger = "0.10"
 log = "0.4"

--- a/examples/aya-tool/myapp/src/main.rs
+++ b/examples/aya-tool/myapp/src/main.rs
@@ -8,7 +8,6 @@ use std::{
     thread,
     time::Duration,
 };
-use structopt::StructOpt;
 
 fn main() {
     if let Err(e) = try_main() {
@@ -16,13 +15,7 @@ fn main() {
     }
 }
 
-#[derive(Debug, StructOpt)]
-struct Opt {}
-
 fn try_main() -> Result<(), anyhow::Error> {
-    // command-line options a currently unused
-    let _opt = Opt::from_args();
-
     env_logger::init();
 
     // This will include your eBPF object file as raw bytes at compile-time and load it at


### PR DESCRIPTION
Remove unused structopt dependency - no command-line parameters are expected or needed by this example.