### PR TITLE
sync tc-egress example with aya-template

### DIFF
--- a/examples/tc-egress/tc-egress-common/Cargo.toml
+++ b/examples/tc-egress/tc-egress-common/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [features]
 default = []
-user = [ "aya" ]
+user = ["aya"]
 
 [dependencies]
-aya = { version = ">=0.11", optional=true }
+aya = { version = ">=0.11", optional = true }
 
 [lib]
 path = "src/lib.rs"

--- a/examples/tc-egress/tc-egress/Cargo.toml
+++ b/examples/tc-egress/tc-egress/Cargo.toml
@@ -5,13 +5,19 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features=["async_tokio"] }
+aya = { version = ">=0.11", features = ["async_tokio"] }
 aya-log = "0.1"
-tc-egress-common = { path = "../tc-egress-common", features=["user"] }
+tc-egress-common = { path = "../tc-egress-common", features = ["user"] }
 anyhow = "1.0.68"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }
 log = "0.4"
-tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }
+tokio = { version = "1.24", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "net",
+    "signal",
+] }
 bytes = "1"
 env_logger = "0.10"
 

--- a/examples/tc-egress/xtask/Cargo.toml
+++ b/examples/tc-egress/xtask/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }
 aya-tool = { git = "https://github.com/aya-rs/aya", branch = "main" }

--- a/examples/tc-egress/xtask/src/build_ebpf.rs
+++ b/examples/tc-egress/xtask/src/build_ebpf.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 use clap::Parser;
 

--- a/examples/tc-egress/xtask/src/main.rs
+++ b/examples/tc-egress/xtask/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     };
 
     if let Err(e) = ret {
-        eprintln!("{:#}", e);
+        eprintln!("{e:#}");
         exit(1);
     }
 }

--- a/examples/tc-egress/xtask/src/run.rs
+++ b/examples/tc-egress/xtask/src/run.rs
@@ -47,10 +47,11 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
 
     // profile we are building (release or debug)
     let profile = if opts.release { "release" } else { "debug" };
-    let bin_path = format!("target/{}/tc-egress", profile);
+    let bin_path = format!("target/{profile}/tc-egress");
 
     // arguments to pass to the application
-    let mut run_args: Vec<_> = opts.run_args.iter().map(String::as_str).collect();
+    let mut run_args: Vec<_> =
+        opts.run_args.iter().map(String::as_str).collect();
 
     // configure args
     let mut args: Vec<_> = opts.runner.trim().split_terminator(' ').collect();
@@ -58,10 +59,11 @@ pub fn run(opts: Options) -> Result<(), anyhow::Error> {
     args.append(&mut run_args);
 
     // spawn the command
-    let err = Command::new(args.get(0).expect("No first argument"))
+    let err = Command::new(args.first().expect("No first argument"))
         .args(args.iter().skip(1))
         .exec();
 
     // we shouldn't get here unless the command failed to spawn
-    Err(anyhow::Error::from(err).context(format!("Failed to run `{}`", args.join(" "))))
+    Err(anyhow::Error::from(err)
+        .context(format!("Failed to run `{}`", args.join(" "))))
 }


### PR DESCRIPTION
PR brings the `tc-egress` example closer to the code generated from aya-template and fixes several minor clippy and rustfmt issues.