### PR TITLE
examples: Declare maps as `static` instead of `static mut`

### DIFF
--- a/examples/aya-tool/myapp-ebpf/src/main.rs
+++ b/examples/aya-tool/myapp-ebpf/src/main.rs
@@ -17,7 +17,7 @@ use aya_bpf::{
 use vmlinux::task_struct;
 
 #[map]
-static mut PROCESSES: HashMap<i32, i32> = HashMap::with_max_entries(32768, 0);
+static PROCESSES: HashMap<i32, i32> = HashMap::with_max_entries(32768, 0);
 
 #[lsm(name = "task_alloc")]
 pub fn task_alloc(ctx: LsmContext) -> i32 {

--- a/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
@@ -18,11 +18,11 @@ mod bindings;
 use bindings::iphdr;
 
 #[map(name = "EVENTS")]
-static mut EVENTS: PerfEventArray<PacketLog> =
+static EVENTS: PerfEventArray<PacketLog> =
     PerfEventArray::with_max_entries(1024, 0);
 
 #[map(name = "BLOCKLIST")] // (1)
-static mut BLOCKLIST: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);
+static BLOCKLIST: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);
 
 #[cgroup_skb(name = "cgroup_skb_egress")]
 pub fn cgroup_skb_egress(ctx: SkBuffContext) -> i32 {
@@ -52,9 +52,7 @@ fn try_cgroup_skb_egress(ctx: SkBuffContext) -> Result<i32, i64> {
         ipv4_address: destination,
         action: action,
     };
-    unsafe {
-        EVENTS.output(&ctx, &log_entry, 0);
-    }
+    EVENTS.output(&ctx, &log_entry, 0);
     Ok(action)
 }
 

--- a/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
+++ b/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
@@ -22,7 +22,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 }
 
 #[map(name = "BLOCKLIST")] // (1)
-static mut BLOCKLIST: HashMap<u32, u32> =
+static BLOCKLIST: HashMap<u32, u32> =
     HashMap::<u32, u32>::with_max_entries(1024, 0);
 
 #[xdp]
@@ -60,7 +60,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     }
 
     let ipv4hdr: *const Ipv4Hdr = unsafe { ptr_at(&ctx, EthHdr::LEN)? };
-    let source =  u32::from_be(unsafe { (*ipv4hdr).src_addr });
+    let source = u32::from_be(unsafe { (*ipv4hdr).src_addr });
 
     // (3)
     let action = if block_ip(source) {


### PR DESCRIPTION
All map types designed to be used for defining maps in eBPF programs are wrapped in `UnsafeCell`, therefore there is no need to declare them as `static mut`.