### PR TITLE
fix: format IP address with `{:i}`

### DIFF
--- a/examples/kprobetcp/kprobetcp-ebpf/src/main.rs
+++ b/examples/kprobetcp/kprobetcp-ebpf/src/main.rs
@@ -44,7 +44,7 @@ fn try_kprobetcp(ctx: ProbeContext) -> Result<u32, i64> {
             });
             info!(
                 &ctx,
-                "AF_INET src address: {:ipv4}, dest address: {:ipv4}",
+                "AF_INET src address: {:i}, dest address: {:i}",
                 src_addr,
                 dest_addr,
             );

--- a/examples/kprobetcp/kprobetcp-ebpf/src/main.rs
+++ b/examples/kprobetcp/kprobetcp-ebpf/src/main.rs
@@ -55,7 +55,7 @@ fn try_kprobetcp(ctx: ProbeContext) -> Result<u32, i64> {
             let dest_addr = sk_common.skc_v6_daddr;
             info!(
                 &ctx,
-                "AF_INET6 src addr: {:ipv6}, dest addr: {:ipv6}",
+                "AF_INET6 src addr: {:i}, dest addr: {:i}",
                 unsafe { src_addr.in6_u.u6_addr8 },
                 unsafe { dest_addr.in6_u.u6_addr8 }
             );

--- a/examples/tc-egress/tc-egress-ebpf/src/main.rs
+++ b/examples/tc-egress/tc-egress-ebpf/src/main.rs
@@ -44,7 +44,7 @@ fn try_tc_egress(ctx: TcContext) -> Result<i32, ()> {
         TC_ACT_PIPE
     };
 
-    info!(&ctx, "DEST {:ipv4}, ACTION {}", destination, action);
+    info!(&ctx, "DEST {:i}, ACTION {}", destination, action);
 
     Ok(action)
 }

--- a/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
+++ b/examples/xdp-drop/xdp-drop-ebpf/src/main.rs
@@ -68,7 +68,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     } else {
         xdp_action::XDP_PASS
     };
-    info!(&ctx, "SRC: {:ipv4}, ACTION: {}", source, action);
+    info!(&ctx, "SRC: {:i}, ACTION: {}", source, action);
 
     Ok(action)
 }

--- a/examples/xdp-log/xdp-log-ebpf/src/main.rs
+++ b/examples/xdp-log/xdp-log-ebpf/src/main.rs
@@ -65,7 +65,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
     // (3)
     info!(
         &ctx,
-        "SRC IP: {:ipv4}, SRC PORT: {}", source_addr, source_port
+        "SRC IP: {:i}, SRC PORT: {}", source_addr, source_port
     );
 
     Ok(xdp_action::XDP_PASS)


### PR DESCRIPTION
`{:ipv4}` has been replaced with `{:i}` in aya-rs/aya#599.

This is causing the following compile error.

```
error: could not parse the format string: unknown display hint: "ipv4"
  --> src/main.rs:68:9
   |
68 |         "SRC IP: {:ipv4}, SRC PORT: {}", source_addr, source_port
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```