### PR TITLE
index: Use the correct verb ("is" instead of "are") for singular entities

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,10 +35,10 @@ Some of the major features provided include:
 ## Who's Using Aya
 
 ### [![Deepfence](https://deepfence.io/wp-content/themes/deepfence/public/img/logo.svg){ width="150"}](https://deepfence.io/)
-Deepfence are using Aya with XDP/TC as their packet filtering stack. See more [here](https://deepfence.io/aya-your-trusty-ebpf-companion/).
+Deepfence is using Aya with XDP/TC as their packet filtering stack. See more [here](https://deepfence.io/aya-your-trusty-ebpf-companion/).
 
 ### [![Exein](https://blog.exein.io/content/images/2023/03/logoexein.png){ width="150"}](https://exein.io)
-Exein are using Aya in [Pulsar](https://pulsar.sh/), a Runtime Security Observability Tool for IoT. See more [here](https://github.com/Exein-io/pulsar).
+Exein is using Aya in [Pulsar](https://pulsar.sh/), a Runtime Security Observability Tool for IoT. See more [here](https://github.com/Exein-io/pulsar).
 
 ### [![Red Hat](https://www.redhat.com/cms/managed-files/Asset-Red_Hat-Logo_page-Logo-RGB.svg?itok=yWDK-rRz){ width="150"}](https://redhat.com)
-Red Hat are using Aya to develop [bpfd](https://github.com/redhat-et/bpfd), an eBPF program loading daemon.
+Red Hat is using Aya to develop [bpfd](https://github.com/redhat-et/bpfd), an eBPF program loading daemon.


### PR DESCRIPTION
Companies like Deepfence, Exein and Red Hat are singular entities, hence the verb should be in singular form.