### PR TITLE
add cross-compilation instructions for MacOS

### DIFF
--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -1,21 +1,27 @@
 # Cross-compiling aya-based programs
 
-The instructions below are for cross-compiling aya eBPF programs
-on Macs. The Windows instructions are on the _TODO_ list - contributions are welcome!
+The instructions below show how to cross compile aya eBPF programs on Macs.
+Cross compiling on other systems is possible too and we're going
+to add instructions to do that soon (PRs welcome!).
 
 # Cross-compiling aya-based programs on Mac
-Cross-compilation should work both on the Intel and M1/M2 Macs.
 
-1. Install `rustup` following the instructions on https://rustup.rs/.
+Cross compilation should work on both Intel and Apple Silicon Macs.
+
+1. Install `rustup` following the instructions on <https://rustup.rs/>
 2. Install a rust stable toolchain: `rustup install stable`
-3. Install a rust nightly toolchain: `rustup toolchain install nightly --component rust-src`
-4. `brew install llvm`.
+3. Install a rust nightly toolchain:  
+`rustup toolchain install nightly --component rust-src`
+4. `brew install llvm`
 5. `brew install FiloSottile/musl-cross/musl-cross`
-6. Install bpf-linker with `--no-default-features`:<br>
-`cargo install bpf-linker --no-default-features`.<br>
-This should work if `llvm-config` is found in the PATH.  If needed, you can also try:
+6. Install bpf-linker:  
 `LLVM_SYS_160_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features`
-7. Build BPF object files: `cargo xtask build-ebpf [--release]`
-8. Build the userspace code. `'-C link-arg=-s'` flag is optional - used to produce a smaller executable file.<br>
-`RUSTFLAGS="-Clinker=x86_64-linux-musl-ld -C link-arg=-s" cargo build --release --target=x86_64-unknown-linux-musl`<br>
-The cross-compiled program `target/x86_64-unknown-linux-musl/release/<program_name>` can be copied to a Linux server or VM (having a capable kernel) and run there.  Don't forget `sudo` if you are not `root`!
+7. Build BPF object files: `cargo xtask build-ebpf --release`
+8. Build the userspace code:  
+```bash
+RUSTFLAGS="-Clinker=x86_64-linux-musl-ld" cargo build --release
+--target=x86_64-unknown-linux-musl
+```
+The cross-compiled program  
+`target/x86_64-unknown-linux-musl/release/<program_name>`
+can be copied to a Linux server or VM and run there.

--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -9,7 +9,7 @@ to add instructions to do that soon (PRs welcome!).
 Cross compilation should work on both Intel and Apple Silicon Macs.
 
 1. Install `rustup` following the instructions on <https://rustup.rs/>
-1. Install a rust stable and nightly toolchains:
+1. Install the stable and nightly rust toolchains:
 ```bash
 rustup install stable
 rustup toolchain install nightly --component rust-src
@@ -26,7 +26,7 @@ brew install llvm
 
 1. Install the musl cross compiler:
 ```bash
-brew install FiloSottile/musl-cross/musl-cross`
+brew install FiloSottile/musl-cross/musl-cross
 ```
 See [homebrew-musl-cross](https://github.com/FiloSottile/homebrew-musl-cross)
 for platform-specific options.
@@ -41,8 +41,7 @@ cargo xtask build-ebpf --release
 ```
 1. Build the userspace code:
 ```bash
-RUSTFLAGS="-Clinker=${ARCH}-linux-musl-ld" cargo build --release
---target=${ARCH}-unknown-linux-musl
+RUSTFLAGS="-Clinker=${ARCH}-linux-musl-ld" cargo build --release --target=${ARCH}-unknown-linux-musl
 ```
 The cross-compiled program  
 `target/${ARCH}-unknown-linux-musl/release/<program_name>`  

--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -1,0 +1,21 @@
+# Cross-compiling aya-based programs
+
+The instructions below are for cross-compiling aya eBPF programs
+on Macs. The Windows instructions are on the _TODO_ list - contributions are welcome!
+
+# Cross-compiling aya-based programs on Mac
+Cross-compilation should work both on the Intel and M1/M2 Macs.
+
+1. Install `rustup` following the instructions on https://rustup.rs/.
+2. Install a rust stable toolchain: `rustup install stable`
+3. Install a rust nightly toolchain: `rustup toolchain install nightly --component rust-src`
+4. `brew install llvm`.
+5. `brew install FiloSottile/musl-cross/musl-cross`
+6. Install bpf-linker with `--no-default-features`:<br>
+`cargo install bpf-linker --no-default-features`.<br>
+This should work if `llvm-config` is found in the PATH.  If needed, you can also try:
+`LLVM_SYS_160_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features`
+7. Build BPF object files: `cargo xtask build-ebpf [--release]`
+8. Build the userspace code. `'-C link-arg=-s'` flag is optional - used to produce a smaller executable file.<br>
+`RUSTFLAGS="-Clinker=x86_64-linux-musl-ld -C link-arg=-s" cargo build --release --target=x86_64-unknown-linux-musl`<br>
+The cross-compiled program `target/x86_64-unknown-linux-musl/release/<program_name>` can be copied to a Linux server or VM (having a capable kernel) and run there.  Don't forget `sudo` if you are not `root`!

--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -9,19 +9,41 @@ to add instructions to do that soon (PRs welcome!).
 Cross compilation should work on both Intel and Apple Silicon Macs.
 
 1. Install `rustup` following the instructions on <https://rustup.rs/>
-2. Install a rust stable toolchain: `rustup install stable`
-3. Install a rust nightly toolchain:  
-`rustup toolchain install nightly --component rust-src`
-4. `brew install llvm`
-5. `brew install FiloSottile/musl-cross/musl-cross`
-6. Install bpf-linker:  
-`LLVM_SYS_160_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features`
-7. Build BPF object files: `cargo xtask build-ebpf --release`
-8. Build the userspace code:  
+1. Install a rust stable and nightly toolchains:
 ```bash
-RUSTFLAGS="-Clinker=x86_64-linux-musl-ld" cargo build --release
---target=x86_64-unknown-linux-musl
+rustup install stable
+rustup toolchain install nightly --component rust-src
+```
+1. Install the [rustup target](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools) for your Linux target platform:
+```bash
+ARCH=x86_64
+rustup target add ${ARCH}-unknown-linux-musl
+```
+1. Install LLVM with brew:
+```bash
+brew install llvm
+```
+
+1. Install the musl cross compiler:
+```bash
+brew install FiloSottile/musl-cross/musl-cross`
+```
+See [homebrew-musl-cross](https://github.com/FiloSottile/homebrew-musl-cross)
+for platform-specific options.
+
+1. Install bpf-linker:
+```bash
+LLVM_SYS_160_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features
+```
+1. Build BPF object files:
+```bash
+cargo xtask build-ebpf --release
+```
+1. Build the userspace code:
+```bash
+RUSTFLAGS="-Clinker=${ARCH}-linux-musl-ld" cargo build --release
+--target=${ARCH}-unknown-linux-musl
 ```
 The cross-compiled program  
-`target/x86_64-unknown-linux-musl/release/<program_name>`
+`target/${ARCH}-unknown-linux-musl/release/<program_name>`  
 can be copied to a Linux server or VM and run there.

--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -24,12 +24,21 @@ rustup target add ${ARCH}-unknown-linux-musl
 brew install llvm
 ```
 
-1. Install the musl cross compiler:
+1. Install the musl cross compiler:  
+to cross-compile for only `x86_64` targets (the default in musl-cross):
 ```bash
 brew install FiloSottile/musl-cross/musl-cross
 ```
+to cross-compile for only `aarch64` targets:
+```bash
+brew install FiloSottile/musl-cross/musl-cross --without-x86_64 --with-aarch64
+```
+to cross-compile for both `x86_64` and `aarch64` targets:
+```bash
+brew install FiloSottile/musl-cross/musl-cross --with-aarch64
+```
 See [homebrew-musl-cross](https://github.com/FiloSottile/homebrew-musl-cross)
-for platform-specific options.
+for additional platform-specific options.
 
 1. Install bpf-linker:
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Reading Values From A Context: book/aya/context.md
       - Using aya-tool: book/aya/aya-tool.md
       - Using aya-log: book/aya/aya-log.md
+      - Cross-compilation: book/aya/crosscompile.md
     - Program Types:
       - book/programs/index.md
       - Probes: book/programs/probes.md


### PR DESCRIPTION
PR adds cross-compilation instructions for MacOS (Windows still _TODO_), taken from https://github.com/dmitris/tcbpftest/blob/main/README.md#cross-compilation