### PR TITLE
Update commands used on Mac to set up environment

### DIFF
--- a/docs/book/aya/crosscompile.md
+++ b/docs/book/aya/crosscompile.md
@@ -44,7 +44,7 @@ for additional platform-specific options.
 to the major version of the [llvm-sys](https://crates.io/crates/llvm-sys) crate:
 
 ```bash
-LLVM_SYS_170_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features
+LLVM_SYS_180_PREFIX=$(brew --prefix llvm) cargo install bpf-linker --no-default-features
 ```
 1. Build BPF object files:
 ```bash

--- a/docs/book/start/development.md
+++ b/docs/book/start/development.md
@@ -24,7 +24,7 @@ install the newest stable version of LLVM first (for example, with `brew install
 then install the linker with:
 
 ```console
-cargo install --no-default-features bpf-linker
+LLVM_SYS_180_PREFIX=$(brew --prefix llvm) cargo install --no-default-features bpf-linker
 ```
 
 To generate the scaffolding for your project, you're going to need


### PR DESCRIPTION
I was following the document and noticed that the command `cargo install bpf-linker --no-default-features` is failing with the following error
```
error: No suitable version of LLVM was found system-wide or pointed
              to by LLVM_SYS_180_PREFIX.
       
              Consider using `llvmenv` to compile an appropriate copy of LLVM, and
              refer to the llvm-sys documentation for more information.
       
              llvm-sys: https://crates.io/crates/llvm-sys
              llvmenv: https://crates.io/crates/llvmenv
   --> /Users/cuichli/.cargo/registry/src/index.crates.io-6f17d22bba15001f/llvm-sys-180.0.0/src/lib.rs:515:1
    |
515 | / std::compile_error!(concat!(
516 | |     "No suitable version of LLVM was found system-wide or pointed
517 | |        to by LLVM_SYS_",
518 | |     env!("CARGO_PKG_VERSION_MAJOR"),
...   |
525 | |        llvmenv: https://crates.io/crates/llvmenv"
526 | | ));
    | |__^
```

Hence I made this PR to update it. Note: I am not sure if there is a more general environment variable to specify the PREFIX.

Please kindly correct me if I got anything wrong. Thanks!