### PR TITLE
Remove use of PerfEventArray::with_max_entries

### DIFF
--- a/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
@@ -18,8 +18,7 @@ mod bindings;
 use bindings::iphdr;
 
 #[map]
-static EVENTS: PerfEventArray<PacketLog> =
-    PerfEventArray::with_max_entries(1024, 0);
+static EVENTS: PerfEventArray<PacketLog> = PerfEventArray::new(1024, 0);
 
 #[map] // (1)
 static BLOCKLIST: HashMap<u32, u32> = HashMap::with_max_entries(1024, 0);


### PR DESCRIPTION
Removed in
https://github.com/aya-rs/aya/commit/ef0d1253efcc5a385afc74668d4f28580d328822.
