### PR TITLE
Link and wording fix: lsm.md

### DIFF
--- a/docs/book/programs/lsm.md
+++ b/docs/book/programs/lsm.md
@@ -30,9 +30,9 @@ include:
   * receiving and sending messages
 
 Each of those actions has a corresponding LSM hook. Each hook takes a number of
-arguments, which provides context about the program and it's operation in order to implement policy
-decisions. The list of hooks with their arguments can be found in the
-[lsm_hook_defs.h](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hook_defs.h)
+arguments, which provides context about the program and it's operation in order
+to implement policy decisions. The list of hooks with their arguments can be 
+found in the [lsm_hook_defs.h](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hook_defs.h)
 header.
 
 For example, consider the `task_setnice` hook, which has the following

--- a/docs/book/programs/lsm.md
+++ b/docs/book/programs/lsm.md
@@ -29,11 +29,9 @@ include:
   * creating and binding sockets
   * receiving and sending messages
 
-Each of those actions has a corresponding LSM hook. All LSM hooks are listed in
-the [lsm_hooks.h](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hooks.h)
-header inside the Linux kernel source code. Each hook takes a number of
-arguments, which provide context based on which programs can implement policy
-decisions and are listed in the
+Each of those actions has a corresponding LSM hook. Each hook takes a number of
+arguments, which provides context about the program and it's operation in order to implement policy
+decisions. The list of hooks with their arguments can be found in the
 [lsm_hook_defs.h](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hook_defs.h)
 header.
 


### PR DESCRIPTION
[lsm_hooks.h](https://github.com/torvalds/linux/blob/master/include/linux/lsm_hooks.h) does not appear to actually list the hooks as stated in the original text, rather it contains definitions for a data structure providing the list during execution. I also found the wording to be slightly confusing, as to my understanding, the author of the LSM module is the one making the policy decisions.

If I'm ignorant to something please let me know, it's my first day working with BPF 🐝