### PR TITLE
Add necessary package installation info for debian based distro

### DIFF
--- a/docs/book/start/development.md
+++ b/docs/book/start/development.md
@@ -19,6 +19,9 @@ the rust toolchain if you are running **on a linux x86_64 system** with:
 cargo install bpf-linker
 ```
 
+> On Debian based distributions, you need to install the `llvm-19-dev`,
+> `libclang-19-dev` and `libpolly-19-dev` packages (if using LLVM 19).
+
 If you are running **macos, or linux on any other architecture**, you need to
 install the newest stable version of LLVM first (for example, with
 `brew install llvm`), then install the linker with:


### PR DESCRIPTION
bpf-linker installation on debian distro requires additional packages, which only updated in https://github.com/aya-rs/bpf-linker yet to the book.