### PR TITLE
Update aya_tool reference

### DIFF
--- a/examples/cgroup-skb-egress/xtask/src/main.rs
+++ b/examples/cgroup-skb-egress/xtask/src/main.rs
@@ -15,7 +15,7 @@ enum Command {
 fn main() -> Result<()> {
     match Parser::parse() {
         Command::Codegen { output } => {
-            let bindings = aya_tool::generate(
+            let bindings = aya_tool::generate::generate(
                 aya_tool::generate::InputFile::Btf(std::path::PathBuf::from(
                     "/sys/kernel/btf/vmlinux",
                 )),


### PR DESCRIPTION
`generate` is no longer reexported from the root.
