### PR TITLE
Move `enable-beta-ecosystems: true` to the correct level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "cargo"
     directories:
@@ -17,7 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    enable-beta-ecosystems: true
     groups:
       python-packages:
         patterns:


### PR DESCRIPTION
Currently we're seeing `The enable-beta-ecosystems setting must be true to use the package-ecosystem uv.`

See https://github.blog/changelog/2022-04-05-pub-beta-support-for-dependabot-version-updates/.