### PR TITLE
Fix example build scripts

### DIFF
--- a/examples/aya-tool/myapp/build.rs
+++ b/examples/aya-tool/myapp/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "myapp-ebpf")
         .ok_or_else(|| anyhow!("myapp-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/cgroup-skb-egress/cgroup-skb-egress/build.rs
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -13,5 +13,5 @@ fn main() -> anyhow::Result<()> {
             name == "cgroup-skb-egress-ebpf"
         })
         .ok_or_else(|| anyhow!("cgroup-skb-egress-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/kprobetcp/kprobetcp/build.rs
+++ b/examples/kprobetcp/kprobetcp/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "kprobetcp-ebpf")
         .ok_or_else(|| anyhow!("kprobetcp-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/lsm-nice/lsm-nice/build.rs
+++ b/examples/lsm-nice/lsm-nice/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "lsm-nice-ebpf")
         .ok_or_else(|| anyhow!("lsm-nice-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/tc-egress/tc-egress/build.rs
+++ b/examples/tc-egress/tc-egress/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "tc-egress-ebpf")
         .ok_or_else(|| anyhow!("tc-egress-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/xdp-drop/xdp-drop/build.rs
+++ b/examples/xdp-drop/xdp-drop/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "xdp-drop-ebpf")
         .ok_or_else(|| anyhow!("xdp-drop-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/xdp-hello/xdp-hello/build.rs
+++ b/examples/xdp-hello/xdp-hello/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "xdp-hello-ebpf")
         .ok_or_else(|| anyhow!("xdp-hello-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }

--- a/examples/xdp-log/xdp-log/build.rs
+++ b/examples/xdp-log/xdp-log/build.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context as _};
-use aya_build::cargo_metadata;
+use aya_build::{cargo_metadata, Toolchain};
 
 fn main() -> anyhow::Result<()> {
     let cargo_metadata::Metadata { packages, .. } =
@@ -11,5 +11,5 @@ fn main() -> anyhow::Result<()> {
         .into_iter()
         .find(|cargo_metadata::Package { name, .. }| name == "xdp-log-ebpf")
         .ok_or_else(|| anyhow!("xdp-log-ebpf package not found"))?;
-    aya_build::build_ebpf([ebpf_package])
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
 }


### PR DESCRIPTION
Since aya-build was modified to allow specifying a toolchain, 
I updated the build scripts to use the default toolchain.

Related to : #216 