### PR TITLE
Fix link to search tcp-connect on elixir for fixed linux version(v6.16.9)

### DIFF
--- a/docs/book/programs/probes.md
+++ b/docs/book/programs/probes.md
@@ -67,4 +67,4 @@ $ RUST_LOG=info cargo run --config 'target."cfg(all())".runner="sudo -E"'
 
 [source-code]: https://github.com/aya-rs/book/tree/main/examples/kprobetcp
 [kernel-docs]: https://docs.kernel.org/trace/kprobes.html
-[tcp-connect]: https://elixir.bootlin.com/linux/latest/source/net/ipv4/tcp_output.c#L3837
+[tcp-connect]: https://elixir.bootlin.com/linux/latest/A/ident/tcp_connect

--- a/docs/book/programs/probes.md
+++ b/docs/book/programs/probes.md
@@ -67,4 +67,4 @@ $ RUST_LOG=info cargo run --config 'target."cfg(all())".runner="sudo -E"'
 
 [source-code]: https://github.com/aya-rs/book/tree/main/examples/kprobetcp
 [kernel-docs]: https://docs.kernel.org/trace/kprobes.html
-[tcp-connect]: https://elixir.bootlin.com/linux/latest/A/ident/tcp_connect
+[tcp-connect]: https://elixir.bootlin.com/linux/v6.16.9/source/net/ipv4/tcp_output.c#L4073


### PR DESCRIPTION
While linux kernel code is changing, link to `tcp_connect` symbol is not matched with specific line.
How about change link with search result?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/book/241)
<!-- Reviewable:end -->
