### PR TITLE
fix: instructions for `llvm-objdump`ing eBPF artifact

### DIFF
--- a/src/book/start/hello-xdp.md
+++ b/src/book/start/hello-xdp.md
@@ -40,14 +40,26 @@ Now we can compile this using `cargo build`.
 
 ### Verifying The Program
 
-Let's take a look at the compiled eBPF program:
+In order to find the most recent eBPF artifact, we need to look for the newest
+build folder for the `xdp-hello` project in
+`target/debug/build/xdp-hello-<hash>/out/xdp-hello`.
+This artifact can then be inspected using `llvm-objdump`.
+
+```console
+NEWEST_EBPF_ARTIFACT=$(
+  find target/debug/build/ -type f -name xdp-hello -printf '%T@ %p\n' \
+    | sort -n \
+    | tail -n1 \
+    | cut -d' ' -f2-
+)
+
+llvm-objdump -S "$NEWEST_EBPF_ARTIFACT"
+```
 
 <!-- markdownlint-disable MD010 -->
 
 ```console
-$ llvm-objdump -S target/bpfel-unknown-none/debug/xdp-hello
-
-target/bpfel-unknown-none/debug/xdp-hello:	file format elf64-bpf
+target/debug/build/xdp-hello-<hash>/out/xdp-hello:	file format elf64-bpf
 
 Disassembly of section .text:
 


### PR DESCRIPTION
Hello there!

Currently getting into eBPF and aya. I ran into some verifier errors and wanted to look at the generated bytecode.
However, it seems the output directory of the eBPF artifact generated by aya has changed in the last two years since the guide was written. Nowadays, `aya_build` uses `rustc`'s `OUT_DIR`. Therefore, the docs on inspecting the compiled eBPF artifact were outdated.

Let me know if you want me to change anything ^^'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/book/265)
<!-- Reviewable:end -->
