### PR TITLE
Complete socket example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .venv
 site
+Cargo.lock
+target

--- a/examples/hello-sockops/Cargo.toml
+++ b/examples/hello-sockops/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = ["hello-sockops", "hello-sockops-ebpf"]
+
+resolver = "2"
+
+default-members = ["hello-sockops"]
+
+[workspace.package]
+edition = "2024"
+
+[profile.release.package.hello-sockops-ebpf]
+debug = 2
+codegen-units = 1

--- a/examples/hello-sockops/README.md
+++ b/examples/hello-sockops/README.md
@@ -1,0 +1,15 @@
+# hello-sockops
+
+## Prerequisites
+
+1. Install a rust stable toolchain: `rustup install stable`
+1. Install a rust nightly toolchain: `rustup install nightly`
+1. Install bpf-linker: `cargo install bpf-linker`
+
+## Build & Run
+
+Use `cargo build`, `cargo check`, etc. as normal. Run your program with:
+
+```shell
+RUST_LOG=warn cargo run --config 'target."cfg(all())".runner="sudo -E"'
+```

--- a/examples/hello-sockops/hello-sockops-ebpf/Cargo.toml
+++ b/examples/hello-sockops/hello-sockops-ebpf/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hello-sockops-ebpf"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+aya-ebpf = { git = "https://github.com/aya-rs/aya" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya" }
+
+[build-dependencies]
+which = { version = "8.0.0", default-features = false, features = ["real-sys"] }
+
+[[bin]]
+name = "hello-sockops"
+path = "src/main.rs"

--- a/examples/hello-sockops/hello-sockops-ebpf/build.rs
+++ b/examples/hello-sockops/hello-sockops-ebpf/build.rs
@@ -1,0 +1,17 @@
+use which::which;
+
+/// Building this crate has an undeclared dependency on the `bpf-linker` binary. This would be
+/// better expressed by [artifact-dependencies][bindeps] but issues such as
+/// https://github.com/rust-lang/cargo/issues/12385 make their use impractical for the time being.
+///
+/// This file implements an imperfect solution: it causes cargo to rebuild the crate whenever the
+/// mtime of `which bpf-linker` changes. Note that possibility that a new bpf-linker is added to
+/// $PATH ahead of the one used as the cache key still exists. Solving this in the general case
+/// would require rebuild-if-changed-env=PATH *and* rebuild-if-changed={every-directory-in-PATH}
+/// which would likely mean far too much cache invalidation.
+///
+/// [bindeps]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html?highlight=feature#artifact-dependencies
+fn main() {
+    let bpf_linker = which("bpf-linker").unwrap();
+    println!("cargo:rerun-if-changed={}", bpf_linker.to_str().unwrap());
+}

--- a/examples/hello-sockops/hello-sockops-ebpf/src/main.rs
+++ b/examples/hello-sockops/hello-sockops-ebpf/src/main.rs
@@ -1,0 +1,45 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{macros::sock_ops, programs::SockOpsContext, EbpfContext};
+use aya_log_ebpf::{info, warn};
+
+// Cannot do `cargo add libc` due to no_std.
+const AF_INET: u32 = 2;
+
+#[sock_ops]
+pub fn socket_ops(ctx: SockOpsContext) -> u32 {
+    match try_socket_ops(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret.try_into().unwrap_or(1),
+    }
+}
+
+fn try_socket_ops(ctx: SockOpsContext) -> Result<u32, i64> {
+    // `ctx.op()` specifies the type of operation this eBPF program should perform.
+    // So a sock_ops program will often start by matching on it.
+    info!(&ctx, "started..");
+    if ctx.family() == AF_INET {
+        let local_ipv4_addr = ctx.local_ip4();
+        let local_port = ctx.local_port();
+        let pid = ctx.pid();
+        warn!(
+            &ctx,
+            "PID {} | from {}:{} | op {}",
+            pid,
+            local_ipv4_addr,
+            local_port,
+            ctx.op()
+        );
+    }
+
+    // From https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS
+    // the program should return 1 on success.
+    Ok(1)
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/examples/hello-sockops/hello-sockops-ebpf/src/main.rs
+++ b/examples/hello-sockops/hello-sockops-ebpf/src/main.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use aya_ebpf::{macros::sock_ops, programs::SockOpsContext, EbpfContext};
+use aya_ebpf::{EbpfContext, macros::sock_ops, programs::SockOpsContext};
 use aya_log_ebpf::{info, warn};
 
 // Cannot do `cargo add libc` due to no_std.

--- a/examples/hello-sockops/hello-sockops/Cargo.toml
+++ b/examples/hello-sockops/hello-sockops/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hello-sockops"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[dependencies]
+aya = { git = "https://github.com/aya-rs/aya" }
+aya-log = { git = "https://github.com/aya-rs/aya" }
+anyhow = "1"
+env_logger = "0.11"
+log = "0.4"
+
+[build-dependencies]
+aya-build = { git = "https://github.com/aya-rs/aya" }
+anyhow = "1"
+cargo_metadata = "0.23.0"
+hello-sockops-ebpf = { path = "../hello-sockops-ebpf" }
+
+[[bin]]
+name = "hello-sockops"
+path = "src/main.rs"

--- a/examples/hello-sockops/hello-sockops/build.rs
+++ b/examples/hello-sockops/hello-sockops/build.rs
@@ -1,0 +1,30 @@
+use anyhow::{Context as _, anyhow};
+use aya_build::Toolchain;
+
+fn main() -> anyhow::Result<()> {
+    let cargo_metadata::Metadata { packages, .. } =
+        cargo_metadata::MetadataCommand::new()
+            .no_deps()
+            .exec()
+            .context("MetadataCommand::exec")?;
+    let ebpf_package = packages
+        .into_iter()
+        .find(|cargo_metadata::Package { name, .. }| {
+            name.as_str() == "hello-sockops-ebpf"
+        })
+        .ok_or_else(|| anyhow!("hello-sockops-ebpf package not found"))?;
+    let cargo_metadata::Package {
+        name,
+        manifest_path,
+        ..
+    } = ebpf_package;
+    let ebpf_package = aya_build::Package {
+        name: name.as_str(),
+        root_dir: manifest_path
+            .parent()
+            .ok_or_else(|| anyhow!("no parent for {manifest_path}"))?
+            .as_str(),
+        ..Default::default()
+    };
+    aya_build::build_ebpf([ebpf_package], Toolchain::default())
+}

--- a/examples/hello-sockops/hello-sockops/src/main.rs
+++ b/examples/hello-sockops/hello-sockops/src/main.rs
@@ -1,0 +1,35 @@
+use anyhow::Context as _;
+use log::warn;
+
+fn main() -> anyhow::Result<()> {
+    let mut ebpf_sockops = aya::Ebpf::load(aya::include_bytes_aligned!(
+        concat!(env!("OUT_DIR"), "/hello-sockops")
+    ))?;
+
+    env_logger::init();
+    let mut logger = match aya_log::EbpfLogger::init(&mut ebpf_sockops) {
+        Err(e) => {
+            warn!("failed to initialize eBPF logger: {e}");
+            None
+        }
+        Ok(logger) => Some(logger),
+    };
+
+    let program_name = "socket_ops";
+    let program: &mut aya::programs::SockOps = ebpf_sockops
+        .program_mut(program_name)
+        .expect(format!("no eBPF program named {program_name}").as_str())
+        .try_into()?;
+    program.load()?;
+    let root_cg_file = std::fs::File::open("/sys/fs/cgroup")?;
+    program
+        .attach(root_cg_file, aya::programs::CgroupAttachMode::Single)
+        .context("failed to attach the SockOps to root cgroup")?;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Some(logger) = logger.as_mut() {
+            logger.flush();
+        }
+    }
+}

--- a/examples/hello-sockops/hello-sockops/src/main.rs
+++ b/examples/hello-sockops/hello-sockops/src/main.rs
@@ -15,10 +15,10 @@ fn main() -> anyhow::Result<()> {
         Ok(logger) => Some(logger),
     };
 
-    let program_name = "socket_ops";
+    let PROGRAM_NAME: &str = "socket_ops";
     let program: &mut aya::programs::SockOps = ebpf_sockops
-        .program_mut(program_name)
-        .expect(format!("no eBPF program named {program_name}").as_str())
+        .program_mut(PROGRAM_NAME)
+        .expect(format!("no eBPF program named {PROGRAM_NAME}").as_str())
         .try_into()?;
     program.load()?;
     let root_cg_file = std::fs::File::open("/sys/fs/cgroup")?;

--- a/examples/hello-sockops/hello-sockops/src/main.rs
+++ b/examples/hello-sockops/hello-sockops/src/main.rs
@@ -15,11 +15,9 @@ fn main() -> anyhow::Result<()> {
         Ok(logger) => Some(logger),
     };
 
-    let PROGRAM_NAME: &str = "socket_ops";
-    let program: &mut aya::programs::SockOps = ebpf_sockops
-        .program_mut(PROGRAM_NAME)
-        .expect(format!("no eBPF program named {PROGRAM_NAME}").as_str())
-        .try_into()?;
+    const PROGRAM_NAME: &str = "socket_ops";
+    let program: &mut aya::programs::SockOps =
+        ebpf_sockops.program_mut(PROGRAM_NAME).unwrap().try_into()?;
     program.load()?;
     let root_cg_file = std::fs::File::open("/sys/fs/cgroup")?;
     program

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -4,10 +4,14 @@
 
 ## Program example
 
-You can follow the [basic XDP example](../start/development.md#starting-a-new-project) to make a project structure.
+You can follow the
+[basic XDP example](../start/development.md#starting-a-new-project)
+to make a project structure.
+
 E.g.: `cargo generate --name hello-sockops -d program_type=sock_ops https://github.com/aya-rs/aya-template`
 
 Below is the eBPF part of the program (`hello-sockops-ebpf/src/main.rs`) commented:
+
 ```rust
 #![no_std]
 #![no_main]
@@ -16,8 +20,10 @@ use aya_ebpf::{EbpfContext, macros::sock_ops, programs::SockOpsContext};
 use aya_log_ebpf::{info, warn};
 
 enum SockOpsResult {
-    // From the official docs: Regardless of the type of operation, the program should always return 1 on success.
-    //                         A negative integer indicate a operation is not supported.
+    // From the official docs:
+    //   Regardless of the type of operation,
+    //   the program should always return 1 on success.
+    //   A negative integer indicate a operation is not supported.
     Ok = 1,
     #[allow(dead_code)]
     Err = 2, // Some other number to indicate error
@@ -41,7 +47,7 @@ fn try_socket_ops(ctx: SockOpsContext) -> SockOpsResult {
     //     ...
     // }
     // ```
-    // This program just dumps information about the captured INET socket operation
+    // The program just dumps information about captured INET socket operation
     info!(&ctx, "started..");
     if ctx.family() == AF_INET {
         let local_ipv4_addr = ctx.local_ip4();
@@ -68,14 +74,13 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 ```
 
 The following userspace code loads the above program:
+
 ```rust
 use anyhow::Context as _;
 
 fn main() -> anyhow::Result<()> {
-    let mut ebpf_sockops = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
-        env!("OUT_DIR"),
-        "/hello-sockops"
-    )))?;
+    let mut ebpf_sockops = aya::Ebpf::load(aya::include_bytes_aligned!(
+        concat!(env!("OUT_DIR"), "/hello-sockops")))?;
 
     env_logger::init();
     let mut logger = match aya_log::EbpfLogger::init(&mut ebpf_sockops) {
@@ -106,4 +111,6 @@ fn main() -> anyhow::Result<()> {
 }
 ```
 
-Try to start the program with `RUST_LOG=warn cargo run` and run `curl goo.gle` in another terminal to see information on the new socket.
+Try to start the program with `RUST_LOG=warn cargo run` and run `curl goo.gle`
+in another terminal to see information on the new socket logged
+by the eBPF program.

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -1,3 +1,109 @@
 # Sockets
 
-This page is a work in progress, please feel free to open a Pull Request!
+[Official eBPF program type description](https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS)
+
+## Program example
+
+You can follow the [basic XDP example](../start/development.md#starting-a-new-project) to make a project structure.
+E.g.: `cargo generate --name hello-sockops -d program_type=sock_ops https://github.com/aya-rs/aya-template`
+
+Below is the eBPF part of the program (`hello-sockops-ebpf/src/main.rs`) commented:
+```rust
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{EbpfContext, macros::sock_ops, programs::SockOpsContext};
+use aya_log_ebpf::{info, warn};
+
+enum SockOpsResult {
+    // From the official docs: Regardless of the type of operation, the program should always return 1 on success.
+    //                         A negative integer indicate a operation is not supported.
+    Ok = 1,
+    #[allow(dead_code)]
+    Err = 2, // Some other number to indicate error
+}
+
+// Cannot do `cargo add libc` due to no_std
+// use libc::AF_INET;
+const AF_INET: u32 = 2;
+
+#[sock_ops]
+pub fn socket_ops(ctx: SockOpsContext) -> u32 {
+    try_socket_ops(ctx) as u32
+}
+
+fn try_socket_ops(ctx: SockOpsContext) -> SockOpsResult {
+    // ctx.op() specifies the type of operation this eBPF program should perform.
+    // So, sock_ops program will look like this most of the time:
+    // ```
+    // match ctx.op() {
+    //     aya_ebpf::bindings::BPF_SOCK_OPS_NEEDS_ECN => { ... }
+    //     ...
+    // }
+    // ```
+    // This program just dumps information about the captured INET socket operation
+    info!(&ctx, "started..");
+    if ctx.family() == AF_INET {
+        let local_ipv4_addr = ctx.local_ip4();
+        let local_port = ctx.local_port();
+        let pid = ctx.pid();
+        warn!(
+            ctx,
+            "PID {} | from {}:{} | op {}",
+            pid,
+            local_ipv4_addr,
+            local_port,
+            ctx.op()
+        );
+    }
+    SockOpsResult::Ok
+}
+
+// Stub panic handler to please the compiler
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+```
+
+The following userspace code loads the above program:
+```rust
+use anyhow::Context as _;
+
+fn main() -> anyhow::Result<()> {
+    let mut ebpf_sockops = aya::Ebpf::load(aya::include_bytes_aligned!(concat!(
+        env!("OUT_DIR"),
+        "/hello-sockops"
+    )))?;
+
+    env_logger::init();
+    let mut logger = match aya_log::EbpfLogger::init(&mut ebpf_sockops) {
+        Err(e) => {
+            log::warn!("failed to initialize eBPF logger: {e}");
+            None
+        }
+        Ok(logger) => Some(logger),
+    };
+
+    let program_name = "socket_ops";
+    let program: &mut aya::programs::SockOps = ebpf_sockops
+        .program_mut(program_name)
+        .expect(format!("no eBPF program named {program_name}").as_str())
+        .try_into()?;
+    program.load()?;
+    let root_cg_file = std::fs::File::open("/sys/fs/cgroup")?;
+    program
+        .attach(root_cg_file, aya::programs::CgroupAttachMode::Single)
+        .context("failed to attach the SockOps to root cgroup")?;
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if let Some(logger) = logger.as_mut() {
+            logger.flush();
+        }
+    }
+}
+```
+
+Try to start the program with `RUST_LOG=warn cargo run` and run `curl goo.gle` in another terminal to see information on the new socket.

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -1,6 +1,6 @@
 # Sockets
 
-[Official eBPF program type description](https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS)
+[eBPF program type description](https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS)
 
 ## Program example
 
@@ -20,7 +20,7 @@ use aya_ebpf::{EbpfContext, macros::sock_ops, programs::SockOpsContext};
 use aya_log_ebpf::{info, warn};
 
 enum SockOpsResult {
-    // From the official docs:
+    // From https://docs.ebpf.io:
     //   Regardless of the type of operation,
     //   the program should always return 1 on success.
     //   A negative integer indicate a operation is not supported.

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -65,7 +65,6 @@ fn try_socket_ops(ctx: SockOpsContext) -> SockOpsResult {
     SockOpsResult::Ok
 }
 
-// Stub panic handler to please the compiler
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -18,9 +18,9 @@ E.g.: `cargo generate --name hello-sockops -d program_type=sock_ops https://gith
 This example logs IPv4 socket information from a SockOps program.
 The program:
 
-- checks whether the socket family is `AF_INET`,
-- reads the local address, local port, and current pid from `SockOpsContext`,
-- logs the operation and returns `1` to indicate success.
+- Checks whether the socket family is `AF_INET`,
+- Reads the local address, local port, and current pid from `SockOpsContext`,
+- Logs the operation and returns `1` to indicate success.
 
 Here's how the eBPF code looks like:
 

--- a/src/book/programs/sockets.md
+++ b/src/book/programs/sockets.md
@@ -1,8 +1,11 @@
 # Sockets
 
-[eBPF program type description](https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS)
+> [!NOTE]
+> Full code for the example in this chapter is available [on GitHub][source-code].
 
-## Program example
+[eBPF program type description][sock-ops-docs]
+
+## Example project
 
 You can follow the
 [basic XDP example](../start/development.md#starting-a-new-project)
@@ -10,106 +13,35 @@ to make a project structure.
 
 E.g.: `cargo generate --name hello-sockops -d program_type=sock_ops https://github.com/aya-rs/aya-template`
 
-Below is the eBPF part of the program (`hello-sockops-ebpf/src/main.rs`) commented:
+## eBPF code
 
-```rust
-#![no_std]
-#![no_main]
+This example logs IPv4 socket information from a SockOps program.
+The program:
 
-use aya_ebpf::{EbpfContext, macros::sock_ops, programs::SockOpsContext};
-use aya_log_ebpf::{info, warn};
+- checks whether the socket family is `AF_INET`,
+- reads the local address, local port, and current pid from `SockOpsContext`,
+- logs the operation and returns `1` to indicate success.
 
-enum SockOpsResult {
-    // From https://docs.ebpf.io:
-    //   Regardless of the type of operation,
-    //   the program should always return 1 on success.
-    //   A negative integer indicate a operation is not supported.
-    Ok = 1,
-    #[allow(dead_code)]
-    Err = 2, // Some other number to indicate error
-}
+Here's how the eBPF code looks like:
 
-// Cannot do `cargo add libc` due to no_std
-// use libc::AF_INET;
-const AF_INET: u32 = 2;
-
-#[sock_ops]
-pub fn socket_ops(ctx: SockOpsContext) -> u32 {
-    try_socket_ops(ctx) as u32
-}
-
-fn try_socket_ops(ctx: SockOpsContext) -> SockOpsResult {
-    // ctx.op() specifies the type of operation this eBPF program should perform.
-    // So, sock_ops program will look like this most of the time:
-    // ```
-    // match ctx.op() {
-    //     aya_ebpf::bindings::BPF_SOCK_OPS_NEEDS_ECN => { ... }
-    //     ...
-    // }
-    // ```
-    // The program just dumps information about captured INET socket operation
-    info!(&ctx, "started..");
-    if ctx.family() == AF_INET {
-        let local_ipv4_addr = ctx.local_ip4();
-        let local_port = ctx.local_port();
-        let pid = ctx.pid();
-        warn!(
-            ctx,
-            "PID {} | from {}:{} | op {}",
-            pid,
-            local_ipv4_addr,
-            local_port,
-            ctx.op()
-        );
-    }
-    SockOpsResult::Ok
-}
-
-#[cfg(not(test))]
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
+```rust,ignore
+{{#include ../../../examples/hello-sockops/hello-sockops-ebpf/src/main.rs}}
 ```
 
-The following userspace code loads the above program:
+## Userspace code
 
-```rust
-use anyhow::Context as _;
+The userspace side loads the compiled eBPF object, initializes Aya's logger,
+loads the `socket_ops` program, and attaches it to the root cgroup.
 
-fn main() -> anyhow::Result<()> {
-    let mut ebpf_sockops = aya::Ebpf::load(aya::include_bytes_aligned!(
-        concat!(env!("OUT_DIR"), "/hello-sockops")))?;
+Here's how the code looks like:
 
-    env_logger::init();
-    let mut logger = match aya_log::EbpfLogger::init(&mut ebpf_sockops) {
-        Err(e) => {
-            log::warn!("failed to initialize eBPF logger: {e}");
-            None
-        }
-        Ok(logger) => Some(logger),
-    };
-
-    let program_name = "socket_ops";
-    let program: &mut aya::programs::SockOps = ebpf_sockops
-        .program_mut(program_name)
-        .expect(format!("no eBPF program named {program_name}").as_str())
-        .try_into()?;
-    program.load()?;
-    let root_cg_file = std::fs::File::open("/sys/fs/cgroup")?;
-    program
-        .attach(root_cg_file, aya::programs::CgroupAttachMode::Single)
-        .context("failed to attach the SockOps to root cgroup")?;
-
-    loop {
-        std::thread::sleep(std::time::Duration::from_millis(100));
-        if let Some(logger) = logger.as_mut() {
-            logger.flush();
-        }
-    }
-}
+```rust,ignore
+{{#include ../../../examples/hello-sockops/hello-sockops/src/main.rs}}
 ```
 
 Try to start the program with `RUST_LOG=warn cargo run` and run `curl goo.gle`
 in another terminal to see information on the new socket logged
 by the eBPF program.
+
+[sock-ops-docs]: https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_SOCK_OPS
+[source-code]: https://github.com/aya-rs/book/tree/main/examples/hello-sockops


### PR DESCRIPTION
This is based on the continuation of this PR, https://github.com/aya-rs/book/pull/256. I have broken down list codeblocks as  two programs  into subfolders of example directory . 

I remove the enum and just have one returned as a success code for SOCKOPS fn.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/book/274)
<!-- Reviewable:end -->
