### PR TITLE
fix(examples): return XDP_PASS for non-TCP/UDP packets in xdp-log

### DIFF
--- a/examples/xdp-log/xdp-log-ebpf/src/main.rs
+++ b/examples/xdp-log/xdp-log-ebpf/src/main.rs
@@ -63,7 +63,7 @@ fn try_xdp_firewall(ctx: XdpContext) -> Result<u32, ()> {
                 ptr_at(&ctx, EthHdr::LEN + Ipv4Hdr::LEN)?;
             unsafe { (*udphdr).src_port() }
         }
-        _ => return Err(()),
+        _ => return Ok(xdp_action::XDP_PASS),
     };
 
     // (3)


### PR DESCRIPTION
Hi maintainers! Thanks for the awesome work on Aya.

While testing the `xdp-log` example, I noticed a slightly unexpected behavior. Currently, non-TCP/UDP IPv4 traffic (like ICMP) hits the `_ => return Err(())` arm in `try_xdp_firewall`. This propagates to the outer function and returns `xdp_action::XDP_ABORTED`.

When the example is loaded, the host cannot be pinged (ICMP requests are unexpectedly dropped), and the kernel frequently triggers `xdp_exception` tracepoints for normal ICMP packets.

I'm wondering if this was an intentional design choice for demonstration purposes?

If it's a minor oversight, this PR changes it to early-return `Ok(xdp_action::XDP_PASS)`. I've tested this locally: ICMP traffic recovers perfectly.

Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/book/277)
<!-- Reviewable:end -->
