### PR TITLE
Fix private field access in cgroup-skb-egress

### DIFF
--- a/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
+++ b/examples/cgroup-skb-egress/cgroup-skb-egress-ebpf/src/main.rs
@@ -28,7 +28,7 @@ fn block_ip(address: u32) -> bool {
 }
 
 fn try_cgroup_skb_egress(ctx: SkBuffContext) -> Result<i32, i64> {
-    let protocol = unsafe { (*ctx.skb.skb).protocol };
+    let protocol = ctx.skb.protocol();
     if protocol != ETH_P_IP {
         return Ok(1);
     }


### PR DESCRIPTION
Updates the eBPF program to use the public `ctx.skb.protocol()` method instead of directly accessing the now-private inner fields via `(*ctx.skb.skb).protocol`. This aligns the example with recent encapsulation changes in Aya.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aya-rs/book/280)
<!-- Reviewable:end -->
